### PR TITLE
Ensure sort lowercase value becomes a string

### DIFF
--- a/vmdb/pipeline.go
+++ b/vmdb/pipeline.go
@@ -90,7 +90,7 @@ func (i *Pipeline) Skip(value int64, defaultValue int64) *Pipeline {
 func (i *Pipeline) SortFields(sort bson.D) *Pipeline {
 	fields := bson.D{}
 	for _, entry := range sort {
-		lower := bson.E{Key: "lower" + entry.Key, Value: bson.D{{Key: "$toLower", Value: "$" + entry.Key}}}
+		lower := bson.E{Key: "lower" + entry.Key, Value: bson.D{{Key: "$toLower", Value: bson.D{{Key: "$toString", Value: "$" + entry.Key}}}}}
 		fields = append(fields, lower)
 	}
 	sortFields := bson.D{{Key: "$addFields", Value: fields}}


### PR DESCRIPTION
see Viva-con-Agua/pool-backend#226 for background

Problem was, that in this very special case, the value to be sorted was a boolean. So the conversion toLower failed.

As you don't seem to have a develop branch here, I put this to main. Please change if necessary.